### PR TITLE
ADD: add some missing icon files

### DIFF
--- a/themes/neonnoir/icons/folder_locales.svg
+++ b/themes/neonnoir/icons/folder_locales.svg
@@ -1,0 +1,19 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_122_1043)">
+<path d="M48.6879 20.1843L49.071 22.2226H51.1449H87.6149C93.0715 22.2226 97.5 26.647 97.5 32.1077V77.9821C97.5 83.4379 93.0708 87.8672 87.6149 87.8672H12.3851C6.92684 87.8672 2.5 83.4383 2.5 77.9821V42.2029V32.1077V22.018C2.5 16.557 6.92612 12.1329 12.3851 12.1329H38.991C43.815 12.1329 47.8259 15.5971 48.6879 20.1843Z" stroke="url(#paint0_linear_122_1043)" stroke-width="5"/>
+<path d="M40.6931 39.1825V33M53.4161 71.3467H67.5726M48.0396 79.59L60.5831 51.1883L73.2153 79.59M34.7799 46.8871C34.7799 46.8871 38.3639 61.8495 54.8495 63.6421M48.0406 39.5406C48.0406 39.5406 47.6815 62.2087 26.4489 63.5523M26 39.2723H55.3872" stroke="url(#paint1_linear_122_1043)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_122_1043" x1="50" y1="9.63287" x2="50" y2="90.3672" gradientUnits="userSpaceOnUse">
+<stop stop-color="#550D38"/>
+<stop offset="0.604167" stop-color="#F80497"/>
+</linearGradient>
+<linearGradient id="paint1_linear_122_1043" x1="49.6077" y1="33" x2="49.6077" y2="79.59" gradientUnits="userSpaceOnUse">
+<stop stop-color="#550D38"/>
+<stop offset="0.604167" stop-color="#F80497"/>
+</linearGradient>
+<clipPath id="clip0_122_1043">
+<rect width="100" height="100" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/themes/neonnoir/icons/folder_locales_open.svg
+++ b/themes/neonnoir/icons/folder_locales_open.svg
@@ -1,0 +1,20 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_122_1047)">
+<path d="M48.6879 20.1843L49.071 22.2226H51.1449H87.6149C93.0715 22.2226 97.5 26.647 97.5 32.1077V77.9821C97.5 83.4379 93.0708 87.8672 87.6149 87.8672H12.3851C6.92684 87.8672 2.5 83.4383 2.5 77.9821V42.2029V32.1077V22.018C2.5 16.557 6.92612 12.1329 12.3851 12.1329H38.991C43.815 12.1329 47.8259 15.5971 48.6879 20.1843Z" stroke="url(#paint0_linear_122_1047)" stroke-width="5"/>
+<path d="M40.6931 39.1825V33M53.4161 71.3467H67.5726M48.0396 79.59L60.5831 51.1883L73.2153 79.59M34.7799 46.8871C34.7799 46.8871 38.3639 61.8495 54.8495 63.6421M48.0406 39.5406C48.0406 39.5406 47.6815 62.2087 26.4489 63.5523M26 39.2723H55.3872" stroke="url(#paint1_linear_122_1047)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_122_1047" x1="50" y1="9.63287" x2="50" y2="90.3672" gradientUnits="userSpaceOnUse">
+<stop stop-color="#550D38"/>
+<stop offset="0.604167" stop-color="#F80497"/>
+</linearGradient>
+<linearGradient id="paint1_linear_122_1047" x1="26.0102" y1="33.1632" x2="80.3248" y2="68.6936" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="0.848958" stop-color="#7F787F"/>
+<stop offset="0.982609" stop-color="#4B454B"/>
+</linearGradient>
+<clipPath id="clip0_122_1047">
+<rect width="100" height="100" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/themes/serene/icons/folder_locales.svg
+++ b/themes/serene/icons/folder_locales.svg
@@ -1,0 +1,21 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_106_2505)">
+<path d="M48.6879 20.1843L49.071 22.2226H51.1449H87.6149C93.0715 22.2226 97.5 26.647 97.5 32.1077V77.9821C97.5 83.4379 93.0708 87.8672 87.6149 87.8672H12.3851C6.92684 87.8672 2.5 83.4383 2.5 77.9821V42.2029V32.1077V22.018C2.5 16.557 6.92612 12.1329 12.3851 12.1329H38.991C43.815 12.1329 47.8259 15.5971 48.6879 20.1843Z" stroke="url(#paint0_linear_106_2505)" stroke-width="5"/>
+<path d="M40.6931 39.1825V33M53.4161 71.3467H67.5726M48.0396 79.59L60.5831 51.1883L73.2153 79.59M34.7799 46.8871C34.7799 46.8871 38.3639 61.8495 54.8495 63.6421M48.0406 39.5406C48.0406 39.5406 47.6815 62.2087 26.4489 63.5523M26 39.2723H55.3872" stroke="url(#paint1_linear_106_2505)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_106_2505" x1="-0.500003" y1="91.5001" x2="103" y2="10.0001" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FDFDFD"/>
+<stop offset="0.453125" stop-color="#D556B6"/>
+<stop offset="0.973958" stop-color="#C94294"/>
+</linearGradient>
+<linearGradient id="paint1_linear_106_2505" x1="25.7639" y1="80.2438" x2="81.7105" y2="44.1993" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FDFDFD"/>
+<stop offset="0.453125" stop-color="#D556B6"/>
+<stop offset="0.973958" stop-color="#C94294"/>
+</linearGradient>
+<clipPath id="clip0_106_2505">
+<rect width="100" height="100" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/themes/serene/icons/folder_locales_open.svg
+++ b/themes/serene/icons/folder_locales_open.svg
@@ -1,0 +1,21 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_106_2509)">
+<path d="M48.6879 20.1843L49.071 22.2226H51.1449H87.6149C93.0715 22.2226 97.5 26.647 97.5 32.1077V77.9821C97.5 83.4379 93.0708 87.8672 87.6149 87.8672H12.3851C6.92684 87.8672 2.5 83.4383 2.5 77.9821V42.2029V32.1077V22.018C2.5 16.557 6.92612 12.1329 12.3851 12.1329H38.991C43.815 12.1329 47.8259 15.5971 48.6879 20.1843Z" stroke="url(#paint0_linear_106_2509)" stroke-width="5"/>
+<path d="M40.6931 39.1825V33M53.4161 71.3467H67.5726M48.0396 79.59L60.5831 51.1883L73.2153 79.59M34.7799 46.8871C34.7799 46.8871 38.3639 61.8495 54.8495 63.6421M48.0406 39.5406C48.0406 39.5406 47.6815 62.2087 26.4489 63.5523M26 39.2723H55.3872" stroke="url(#paint1_linear_106_2509)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_106_2509" x1="-0.500003" y1="91.5001" x2="103" y2="10.0001" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FDFDFD"/>
+<stop offset="0.453125" stop-color="#D556B6"/>
+<stop offset="0.973958" stop-color="#C94294"/>
+</linearGradient>
+<linearGradient id="paint1_linear_106_2509" x1="26.0102" y1="33.1632" x2="80.3248" y2="68.6936" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="0.848958" stop-color="#7F787F"/>
+<stop offset="0.982609" stop-color="#4B454B"/>
+</linearGradient>
+<clipPath id="clip0_106_2509">
+<rect width="100" height="100" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
`neonnoir`
<img width="326" alt="SCR-20240105-jaho" src="https://github.com/jake-the-dev/hotline---icons/assets/3580943/f929f443-222b-492e-ad45-6db327a6cc67">


`serene`
<img width="304" alt="SCR-20240105-jako" src="https://github.com/jake-the-dev/hotline---icons/assets/3580943/a41c4938-9c07-49b8-959b-08d6a9e8915b">

`technicolor`
<img width="298" alt="SCR-20240105-jank" src="https://github.com/jake-the-dev/hotline---icons/assets/3580943/029e6c82-8bf1-4303-ac40-a32a1237ebed">

this should fix it!
